### PR TITLE
Add new flag for HTTP registry

### DIFF
--- a/src/glcli.py
+++ b/src/glcli.py
@@ -46,14 +46,20 @@ def cli():
     default="manifest-entry.json",
     help="A file where the index entry for the pushed manifest is written to.",
 )
+@click.option(
+    "--insecure",
+    default=False,
+    help="Use HTTP to communicate with the registry",
+)
 def push_manifest(
-    container, version, arch, cname, directory, cosign_file, manifest_file
+    container, version, arch, cname, directory, cosign_file, manifest_file, insecure
 ):
     """push artifacts from a dir to a registry, get the index-entry for the manifest in return"""
     container_name = f"{container}:{version}"
     registry = GlociRegistry(
         container_name=container_name,
         token=os.getenv("GLOCI_REGISTRY_TOKEN"),
+        insecure=insecure,
     )
     digest = registry.push_from_dir(arch, version, cname, directory, manifest_file)
     if cosign_file:
@@ -89,12 +95,18 @@ def push_manifest(
 @click.option(
     "--cname", required=True, type=click.Path(), help="Canonical Name of Image"
 )
-def update_index(container, version, manifest_file, arch, cname):
+@click.option(
+    "--insecure",
+    default=False,
+    help="Use HTTP to communicate with the registry",
+)
+def update_index(container, version, manifest_file, arch, cname, insecure):
     """push a index entry from a file to an index"""
     container_name = f"{container}:{version}"
     registry = GlociRegistry(
         container_name=container_name,
         token=os.getenv("GLOCI_REGISTRY_TOKEN"),
+        insecure=insecure,
     )
     registry.update_index_entries(arch, cname, manifest_file, version)
 

--- a/src/registry.py
+++ b/src/registry.py
@@ -130,7 +130,7 @@ class GlociRegistry(Registry):
     def __init__(
         self,
         container_name: str,
-        insecure: bool = True,  # somehow needed, according to logs it is still pushed with https
+        insecure: bool = False,
         token: Optional[str] = None,
         config_path: Optional[str] = None,
     ):


### PR DESCRIPTION
- **Remove docs workflow**
- **poetry update**
- **black formatting**
- **Remove tests, flatten imports**
- **works.**
- **works**
- **remove helper.py and defaults.py**
- **works**
- **nice log message**
- **black formatting**
- **Manage dependencies in requirements.txt**
- **remove poetry & pytest**
- **Add flag to allow http-registries**
