### PR TITLE
mediaType for existing index

### DIFF
--- a/src/registry.py
+++ b/src/registry.py
@@ -195,6 +195,8 @@ class GlociRegistry(Registry):
         try:
             self._check_200_response(response)
             index = response.json()
+            # Ensure mediaType is set for existing indices
+            index["mediaType"] = "application/vnd.oci.image.index.v1+json"
             return index
 
         except ValueError:

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -33,6 +33,7 @@ index = {
     "required": [
         "schemaVersion",
         "manifests",
+        "mediaType",
     ],
     "properties": indexProperties,
     "additionalProperties": True,


### PR DESCRIPTION
Improvement to https://github.com/gardenlinux/python-gardenlinux-cli/pull/37 so that an existing index always gets the correct mediaType as well