### PR TITLE
Remove unused Python package `alabaster`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-alabaster==0.7.16
 apt-repo==0.5
 attrs==24.2.0
 babel==2.16.0


### PR DESCRIPTION
**What this PR does / why we need it**:
While validating changes suggested by @dependabot I found that `alabaster` is not used anywhere.

**Which issue(s) this PR fixes**:
Closes #28